### PR TITLE
Handle error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+
+cmd/carbites

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -151,5 +151,9 @@ func main() {
 		splitCmd,
 		joinCmd,
 	}
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
 }


### PR DESCRIPTION
Currently the cli silently fails when a car file is not passed in. This change prints out the error.