### PR TITLE
Streaming functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+
+cmd/carbites

--- a/carbites.go
+++ b/carbites.go
@@ -29,7 +29,7 @@ func Split(in io.Reader, targetSize int, s Strategy) (Splitter, error) {
 	case Simple:
 		return NewSimpleSplitter(in, targetSize)
 	case Treewalk:
-		return NewTreewalkSplitter(in, targetSize)
+		return nil, fmt.Errorf("treewalk strategy caches the entier CAR, which is not allowed due to memory considerations")
 	default:
 		return nil, fmt.Errorf("unknown strategy %d", s)
 	}

--- a/carbites.go
+++ b/carbites.go
@@ -29,7 +29,7 @@ func Split(in io.Reader, targetSize int, s Strategy) (Splitter, error) {
 	case Simple:
 		return NewSimpleSplitter(in, targetSize)
 	case Treewalk:
-		return nil, fmt.Errorf("treewalk strategy caches the entier CAR, which is not allowed due to memory considerations")
+		return NewTreewalkSplitter(in, targetSize)
 	default:
 		return nil, fmt.Errorf("unknown strategy %d", s)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -151,5 +151,9 @@ func main() {
 		splitCmd,
 		joinCmd,
 	}
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,13 @@ var splitCmd = &cli.Command{
 			fi = bufio.NewReader(os.Stdin)
 		}
 
-		spltr, err := carbites.Split(fi, size, strategy)
+		var spltr carbites.Splitter
+
+		if strategy == carbites.Treewalk {
+			spltr, err = carbites.NewTreewalkSplitterFromPath(path, size)
+		} else {
+			spltr, err = carbites.Split(fi, size, strategy)
+		}
 		if err != nil {
 			return err
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,6 +73,7 @@ var splitCmd = &cli.Command{
 			if err != nil {
 				return err
 			}
+			fi.Close()
 			i++
 		}
 


### PR DESCRIPTION
This is built on top of https://github.com/alanshaw/go-carbites/pull/3 so we can ignore that one.

This adds the ability to stream in a car file:
```
anjor@seven data (main)$ cat 5gb.car | /Users/anjor/repos/alanshaw/go-carbites/cmd/carbites split -s 1000000000
Splitting into ~1000000000 byte chunks using strategy "simple"
Writing CAR chunk to ./stdin-0.car
Writing CAR chunk to ./stdin-1.car
Writing CAR chunk to ./stdin-2.car
Writing CAR chunk to ./stdin-3.car
Writing CAR chunk to ./stdin-4.car
Writing CAR chunk to ./stdin-5.car
```